### PR TITLE
UCSFD8-664 Added alt tag to the card image

### DIFF
--- a/docroot/themes/custom/ucsf/templates/paragraph/paragraph--featured--alt-2.html.twig
+++ b/docroot/themes/custom/ucsf/templates/paragraph/paragraph--featured--alt-2.html.twig
@@ -5,15 +5,16 @@
 {% block wrapper_top %}
   <!-- nid: {{ paragraph.field_news_article.target_id }}  -->
   <article{{ attributes.addClass('news-card') }}>
-  <a href="{{ link }}" class="news-card__link">
+    <a href="{{ link }}" class="news-card__link">
 {% endblock wrapper_top %}
 
 {% block article_image %}
   {# Feature Paragraph > News Article (News) > Card Image #}
   {% set card_image_uri = paragraph.field_news_article.entity.field_card_image.0.entity.field_media_image.entity.fileuri %}
+  {% set card_image_alt = paragraph.field_news_article.entity.field_card_image.0.entity.field_media_image.alt %}
   <figure>
     <picture>
-      <img src="{{ card_image_uri|image_style('featured_news_card__image') }}"/>
+      <img src="{{ card_image_uri|image_style('featured_news_card__image') }}" alt="{{card_image_alt}}"/>
     </picture>
   </figure>
 {% endblock article_image %}


### PR DESCRIPTION
Banner images on the News Center page needed alt attribute. https://ucsfredesign.atlassian.net/browse/UCSFD8-664
