### PR TITLE
fixed error thrown when external url not found

### DIFF
--- a/docroot/modules/custom/conditional_styles/src/EventSubscriber/ConditionalStylesSubscriber.php
+++ b/docroot/modules/custom/conditional_styles/src/EventSubscriber/ConditionalStylesSubscriber.php
@@ -42,7 +42,8 @@ class ConditionalStylesSubscriber implements EventSubscriberInterface {
     if (is_object($node) && $node->hasField('field_article_type')) {
       \Drupal::service('page_cache_kill_switch')->trigger();
       //dpm($node);
-      if ($node->get('field_article_type')->first()->getValue()['target_id'] == '413496') {
+      if ($node->get('field_external_url')->first()
+        && $node->get('field_article_type')->first()->getValue()['target_id'] == '413496') {
         $url = $node->get('field_external_url')->first()->getValue()['uri'];
         $response = new RedirectResponse($url, $this->redirectCode);
         $response->send();


### PR DESCRIPTION
I get the following error on my local when I try to create a news article

The website encountered an unexpected error. Please try again later.
Error: Call to a member function getValue() on null in Drupal\conditional_styles\EventSubscriber\ConditionalStylesSubscriber->customRedirection() (line 46 of modules/custom/conditional_styles/src/EventSubscriber/ConditionalStylesSubscriber.php). 
