### PR TITLE
Fix article layout default template

### DIFF
--- a/docroot/themes/custom/ucsf/templates/components/article/article-layout-default.twig
+++ b/docroot/themes/custom/ucsf/templates/components/article/article-layout-default.twig
@@ -1,5 +1,6 @@
 {% if layout == 'medium' %}
   {% set classes = [ 'article-medium-banner'] %}
+{% endif %}
 
 <figure{{ attributes.addClass(classes) }}>
   {% if content.field_video_banner|render %}
@@ -10,35 +11,29 @@
 </figure>
 
 <div class="main-content narrow-page">
-  {% else %}
-  {% set classes = [ 'main-content', 'narrow-page'] %}
-  <div {{ attributes.addClass(classes) }}>
-    {% endif %}
+  {% if layout == 'medium' and content.field_banner_image|render != '' %}
+    {% set class= 'article-medium-header' %}
+  {% endif %}
 
-    {% if layout == 'medium' and content.field_banner_image|render != '' %}
-      {% set class= 'article-medium-header' %}
-    {% endif %}
+  {% if layout == 'medium' and content.field_video_banner|render != '' %}
+    {% set class= 'article-medium-header article-medium-header-video' %}
+  {% endif %}
 
-    {% if layout == 'medium' and content.field_video_banner|render != '' %}
-      {% set class= 'article-medium-header article-medium-header-video' %}
-    {% endif %}
+  <header class="article-header {{ class }}">
+    {% include '@theme/banner/banner-content.twig' %}
+  </header>
+  {#{% include "@theme/share/share.twig" %}#}
+    <ul class="article-meta-share">
+      <li><a rel="nofollow" href="http://www.facebook.com/share.php?u={{ url('<current>') }}" target="_blank" title="Facebook"><span class="fab fa-facebook-square"></span> <span class="indent-text">Facebook</span></a></li>
 
-    <header class="article-header {{ class }}">
-      {% include '@theme/banner/banner-content.twig' %}
-    </header>
-    {#{% include "@theme/share/share.twig" %}#}
-      <ul class="article-meta-share">
-        <li><a rel="nofollow" href="http://www.facebook.com/share.php?u={{ url('<current>') }}" target="_blank" title="Facebook"><span class="fab fa-facebook-square"></span> <span class="indent-text">Facebook</span></a></li>
+      <li><a rel="nofollow" href="http://www.twitter.com/share?text={{node.label}}&url={{ url('<current>') }}" target="_blank" title="Twitter"><span class="fab fa-twitter-square"></span> <span class="indent-text">Twitter</span></a></li>
 
-        <li><a rel="nofollow" href="http://www.twitter.com/share?text={{node.label}}&url={{ url('<current>') }}" target="_blank" title="Twitter"><span class="fab fa-twitter-square"></span> <span class="indent-text">Twitter</span></a></li>
+      <li><a rel="nofollow" href="http://www.reddit.com/submit?url={{ url('<current>') }}&title={{node.label}}" target="_blank" title="Reddit"><span class="fab fa-reddit-square"></span> <span class="indent-text">Reddit</span></a></li>
 
-        <li><a rel="nofollow" href="http://www.reddit.com/submit?url={{ url('<current>') }}&title={{node.label}}" target="_blank" title="Reddit"><span class="fab fa-reddit-square"></span> <span class="indent-text">Reddit</span></a></li>
+      <li><a rel="nofollow" href="mailto:?to=&subject=From UCSF News: {{node.label}}&body={{node.label}}%0D%0A%0D%0A{{ node.body.summary }}%0D%0A%0D%0A{{ url('<current>') }}" title="Email Article"><span class="fas fa-envelope-square"></span> <span class="indent-text">Email</span></a></li>
 
-        <li><a rel="nofollow" href="mailto:?to=&subject=From UCSF News: {{node.label}}&body={{node.label}}%0D%0A%0D%0A{{ node.body.summary }}%0D%0A%0D%0A{{ url('<current>') }}" title="Email Article"><span class="fas fa-envelope-square"></span> <span class="indent-text">Email</span></a></li>
+      <li><a rel="nofollow" onclick="window.print();return false;" href="{{ url('<current>') }}" title="Print Article"><span class="fas fa-print"></span> <span class="indent-text">Print</span></a></li>
+    </ul>
 
-        <li><a rel="nofollow" onclick="window.print();return false;" href="{{ url('<current>') }}" title="Print Article"><span class="fas fa-print"></span> <span class="indent-text">Print</span></a></li>
-      </ul>
-
-    {% include "@theme/article/article-body.twig" %}
-  </div>
+  {% include "@theme/article/article-body.twig" %}
 </div>


### PR DESCRIPTION
if you copy and paste source code from article into code editor you will see that there is a random `</div>` that is creating malformed HTML. 
 https://www.ucsf.edu/news/2020/08/418281/how-reopen-schools-safely-during-covid-19-according-pediatricians
I've traced the bug to this file.