### PR TITLE
UCSFD8-1112 Entity Embed - Images showing Opacity: 0 do to lazy loading attribute

### DIFF
--- a/docroot/themes/custom/ucsf/assets/css/ckeditor.css
+++ b/docroot/themes/custom/ucsf/assets/css/ckeditor.css
@@ -25,4 +25,7 @@
     -webkit-transform: none;
             transform: none; }
 
+img {
+  opacity: 1 !important; }
+
 /*# sourceMappingURL=ckeditor.css.map */

--- a/docroot/themes/custom/ucsf/scss/ckeditor.scss
+++ b/docroot/themes/custom/ucsf/scss/ckeditor.scss
@@ -31,3 +31,7 @@
     transform: none;
   }
 }
+
+img {
+  opacity: 1 !important;
+}


### PR DESCRIPTION
css is scoped to only run in ckeditor. This will fix the issue for magazine theme as well.